### PR TITLE
Discard faulty but inert target command in src/Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,6 @@ SUBDIRS = leon ctjhai
 .PHONY: all $(SUBDIRS)
 
 all :	$(FILES)
-	cd leon make
 
 leonconv: leonconv.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o leonconv leonconv.c


### PR DESCRIPTION
Discard inert (and certainly forgotten) command in src/Makefile that causes failure with shells whose `cd' command admits at most one path as argument, e.g., bash >= 4.4.5 (closes [Debian bug #849661](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=849661).